### PR TITLE
Reuse expiry time from Invitation in Scheduler

### DIFF
--- a/teams-server/src/main/java/teams/Scheduler.java
+++ b/teams-server/src/main/java/teams/Scheduler.java
@@ -14,13 +14,13 @@ import teams.repository.InvitationRepository;
 import teams.repository.MembershipRepository;
 import teams.repository.PersonRepository;
 
+import static teams.domain.Invitation.EXPIRY_MILLIS;
+
 import java.util.function.Function;
 
 @Configuration
 @EnableScheduling
 public class Scheduler {
-
-    public static final long TWO_WEEKS = 14L * 24L * 60L * 60L * 1000L;
 
     private static final Logger LOG = LoggerFactory.getLogger(Scheduler.class);
 
@@ -43,7 +43,7 @@ public class Scheduler {
 
     @Scheduled(cron = "${cron.expression}")
     public int removeExpiredInvitations() {
-        return this.removeExpired(invitationRepository::deleteExpiredInvitations, System.currentTimeMillis() - TWO_WEEKS, Invitation.class);
+        return this.removeExpired(invitationRepository::deleteExpiredInvitations, System.currentTimeMillis() - EXPIRY_MILLIS, Invitation.class);
     }
 
     @Scheduled(cron = "${cron.expression}")

--- a/teams-server/src/main/java/teams/domain/Invitation.java
+++ b/teams-server/src/main/java/teams/domain/Invitation.java
@@ -27,7 +27,7 @@ import static javax.persistence.FetchType.EAGER;
 public class Invitation implements HashGenerator, Serializable {
 
     public static final long EXPIRY_DAYS = 30L;
-    private static final long THIRTY_DAYS = EXPIRY_DAYS * 24L * 60L * 60L * 1000L;
+    public static final long EXPIRY_MILLIS = EXPIRY_DAYS * 24L * 60L * 60L * 1000L;
 
     @Transient
     public static final java.util.regex.Pattern emailPattern = java.util.regex.Pattern.compile("\\S+@\\S+");
@@ -87,7 +87,7 @@ public class Invitation implements HashGenerator, Serializable {
 
     @JsonProperty(value = "expired", access = JsonProperty.Access.READ_ONLY)
     public boolean expired() {
-        return (timestamp + THIRTY_DAYS) < System.currentTimeMillis();
+        return (timestamp + EXPIRY_MILLIS) < System.currentTimeMillis();
     }
 
     @JsonProperty(value = "daysValid", access = JsonProperty.Access.READ_ONLY)

--- a/teams-server/src/test/java/teams/SchedulerTest.java
+++ b/teams-server/src/test/java/teams/SchedulerTest.java
@@ -11,7 +11,7 @@ import java.time.temporal.ChronoUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
-import static teams.Scheduler.TWO_WEEKS;
+import static teams.domain.Invitation.EXPIRY_MILLIS;
 
 public class SchedulerTest extends AbstractApplicationTest {
 
@@ -41,7 +41,7 @@ public class SchedulerTest extends AbstractApplicationTest {
                 Role.ADMIN,
                 Language.DUTCH,
                 null).addInvitationMessage(personRepository.findOne(1L), "Please join");
-        ReflectionTestUtils.setField(invitation, "timestamp", System.currentTimeMillis() - TWO_WEEKS - (1000L * 3600));//1000L);
+        ReflectionTestUtils.setField(invitation, "timestamp", System.currentTimeMillis() - EXPIRY_MILLIS - (1000L * 3600));//1000L);
         invitationRepository.save(invitation);
 
         int count = scheduler.removeExpiredInvitations();


### PR DESCRIPTION
So scheduler does not delete invitations after two weeks that are still valid
for 16 more days`.