### PR TITLE
Fix for Java 11

### DIFF
--- a/teams-server/pom.xml
+++ b/teams-server/pom.xml
@@ -17,6 +17,21 @@
 
     <dependencies>
         <dependency>
+	   <groupId>com.sun.xml.bind</groupId>
+	   <artifactId>jaxb-core</artifactId>
+	   <version>2.3.0.1</version>
+        </dependency>
+        <dependency>
+	   <groupId>javax.xml.bind</groupId>
+	   <artifactId>jaxb-api</artifactId>
+	   <version>2.3.1</version>
+        </dependency>
+        <dependency>
+	   <groupId>com.sun.xml.bind</groupId>
+	   <artifactId>jaxb-impl</artifactId>
+	   <version>2.3.1</version>
+        </dependency>
+        <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
             <version>5.0.1</version>


### PR DESCRIPTION
Java 11 removed the support for `java.xml.bind`.
See: https://crunchify.com/java-11-and-javax-xml-bind-jaxbcontext/